### PR TITLE
Update 智能视频流识别产品API文档.md

### DIFF
--- a/V2/智能视频流识别产品API文档.md
+++ b/V2/智能视频流识别产品API文档.md
@@ -51,7 +51,6 @@
 ### 请求URL：
 | 集群 | URL | 支持产品列表 |
 | --- | --- | --- |
-| 北京 | `http://api-videostream-bj.fengkongcloud.com/v3/saas/anti_fraud/videostream` | 中文视频流 |
 | 上海 | `http://api-videostream-sh.fengkongcloud.com/v3/saas/anti_fraud/videostream` | 中文视频流 |
 | 新加坡 | `http://api-videostream-xjp.fengkongcloud.com/v3/saas/anti_fraud/videostream` | 中文视频流 |
 | 硅谷 | `http://api-videostream-gg.fengkongcloud.com/v3/saas/anti_fraud/videostream` | 中文视频流 |


### PR DESCRIPTION
V2视频流服务删掉北京集群，因为北京集群合并到上海集群